### PR TITLE
Potential fix for code scanning alert no. 1118: Inefficient regular expression

### DIFF
--- a/myems-web/src/components/MyEMS/auth/SentRegisterEmailMessageForm.js
+++ b/myems-web/src/components/MyEMS/auth/SentRegisterEmailMessageForm.js
@@ -166,7 +166,7 @@ const SentRegisterEmailMessageForm = ({ setRedirect, setRedirectUrl, hasLabel, l
   };
 
   const validateEmail = email => {
-    const regExp = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+    const regExp = /^[a-zA-Z0-9]+([._-][a-zA-Z0-9]+)*@[a-zA-Z0-9-]+(\.[a-zA-Z]{2,})+$/;
     if (regExp.test(email)) {
       setIsSubmitDisabled(true);
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/MyEMS/myems/security/code-scanning/1118](https://github.com/MyEMS/myems/security/code-scanning/1118)

To fix the issue, we need to rewrite the regular expression to remove the ambiguity caused by nested quantifiers. Specifically:
1. Replace `\w+` with a more specific character class that matches valid email address characters.
2. Replace `([\.-]?\w+)*` with a non-ambiguous pattern that avoids nested quantifiers.

The updated regular expression will explicitly define valid email address components while avoiding patterns that can lead to exponential backtracking. The changes will be made in the `validateEmail` function on line 169.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
